### PR TITLE
réparation des dates dans la liste

### DIFF
--- a/src/Service/DateFr.php
+++ b/src/Service/DateFr.php
@@ -83,6 +83,10 @@ class DateFr
 
                 $mois[$k] =  $leMois;
             }
+            else
+            {
+                return null;
+            }
         }
 
         return $mois;
@@ -164,6 +168,11 @@ class DateFr
 
                 $mois[$k] =  $leMois;
             }
+            else
+            {
+                return null;
+            }
+
         }
 
         return $mois;


### PR DESCRIPTION
si aucune personne décédée dans la base de données, le moisDeces n’était pas défini et renvoyait une erreur, 
problème réglé